### PR TITLE
LPAL-1954 - replace deprecated name with region in aws_region data source

### DIFF
--- a/centralise_events/main.tf
+++ b/centralise_events/main.tf
@@ -18,5 +18,5 @@ resource "aws_cloudwatch_event_target" "primary_event_bus" {
   arn       = var.primary_region_event_bus.arn
   role_arn  = var.cross_region_event_bus_role.arn
   rule      = aws_cloudwatch_event_rule.send_to_primary_event_bus.name
-  target_id = "${var.account_name}-${data.aws_region.current.name}-send-to-primary-event-bus"
+  target_id = "${var.account_name}-${data.aws_region.current.region}-send-to-primary-event-bus"
 }

--- a/kms.tf
+++ b/kms.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
         "cloudwatch.amazonaws.com"
       ]
     }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7.0"
+      version = ">= 6.0.0"
       configuration_aliases = [
         aws.eu-west-2,
         aws.us-east-1,


### PR DESCRIPTION
It might be necessary to make releases (maybe not as we have tags) and pin to them in the account module, otherwise merging this is going to immediately affect every account